### PR TITLE
Fix V3025

### DIFF
--- a/MemoryScanner/Program.cs
+++ b/MemoryScanner/Program.cs
@@ -447,7 +447,7 @@ namespace MemoryScanner
                         myargs.setIPaddr(args[3]);
                         myargs.setPortnum(args[4]);
                         myargs.setDelay(args[5]);
-                        Console.WriteLine("Starting search for credit card numbers on procid {0} sending output to {1}:{2} with delay of {4}", myargs.pid.ToString(), myargs.ipaddr, myargs.portnum.ToString(), myargs.delay.ToString());
+                        Console.WriteLine("Starting search for credit card numbers on procid {0} sending output to {1}:{2} with delay of {3}", myargs.pid.ToString(), myargs.ipaddr, myargs.portnum.ToString(), myargs.delay.ToString());
                     }
                 }
                 if (args[1].ToString().Equals("-f"))
@@ -486,7 +486,7 @@ namespace MemoryScanner
                         myargs.setIPaddr(args[3]);
                         myargs.setPortnum(args[4]);
                         myargs.setDelay(args[5]);
-                        Console.WriteLine("Starting search for magnetic stripe data on procid {0} sending output to {1}:{2} with delay of {4}", myargs.pid.ToString(), myargs.ipaddr, myargs.portnum.ToString(), myargs.delay.ToString());
+                        Console.WriteLine("Starting search for magnetic stripe data on procid {0} sending output to {1}:{2} with delay of {3}", myargs.pid.ToString(), myargs.ipaddr, myargs.portnum.ToString(), myargs.delay.ToString());
                     }
                 }
                 if (args[1].ToString().Equals("-f"))


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: 

- Incorrect format. A different number of format items is expected while calling 'WriteLine' function. Format items not used: {4}. Arguments not used: 4th. memscan Program.cs 450

- Incorrect format. A different number of format items is expected while calling 'WriteLine' function. Format items not used: {4}. Arguments not used: 3rd. memscan Program.cs 489